### PR TITLE
修复图片上传接口

### DIFF
--- a/Tool/File/FileImageAd.php
+++ b/Tool/File/FileImageAd.php
@@ -152,6 +152,7 @@ class FileImageAd extends RpcRequest
     {
         RequestCheckUtil::checkNotNull($this->advertiser_id, 'advertiser_id');
         if ($this->upload_type == 'UPLOAD_BY_URL') {
+            $this->content_type = 'application/json';
             RequestCheckUtil::checkNotNull($this->image_url, 'image_url');
         } else {
             RequestCheckUtil::checkNotNull($this->image_signature, 'image_signature');

--- a/Tool/File/FileImageAdvertiser.php
+++ b/Tool/File/FileImageAdvertiser.php
@@ -152,6 +152,7 @@ class FileImageAdvertiser extends RpcRequest
     {
         RequestCheckUtil::checkNotNull($this->advertiser_id, 'advertiser_id');
         if ($this->upload_type == 'UPLOAD_BY_URL') {
+            $this->content_type = 'application/json';
             RequestCheckUtil::checkNotNull($this->image_url, 'image_url');
         } else {
             RequestCheckUtil::checkNotNull($this->image_signature, 'image_signature');


### PR DESCRIPTION
1.上传广告主图片接口，当类型为UPLOAD_BY_URL时，要求为application/json，已更正
2.上传广告图片接口，当类型为UPLOAD_BY_URL时，要求为application/json，已更正